### PR TITLE
(Temporarily) suppressing the projects section

### DIFF
--- a/src/data/menu-items.js
+++ b/src/data/menu-items.js
@@ -1,6 +1,6 @@
 export const menuItems = [
   { label: 'Features', href: '/#features' },
-  { label: 'Projects', href: '/#projects' },
+  // { label: 'Projects', href: '/#projects' }, TODO uncomment when projects are ready
   { label: 'Funders', href: '/#funders' },
   { label: 'Blog', href: '/blog' },
   { label: 'Documentation', href: 'https://docs.oceanparcels.org' },

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -14,7 +14,7 @@ export default function IndexPage() {
     >
       <HeroBanner />
       <Features />
-      <Projects />
+      {/* <Projects /> TODO uncomment when projects are ready */}
       <Funders />
     </Layout>
   )


### PR DESCRIPTION
For now, temporarily suppressing the Projects section of the page. Leaving the code in, as we could later decide to put it back (as highlights?)