### PR TITLE
change date SVP

### DIFF
--- a/src/posts/VS@AWvB_Expedition106/index.md
+++ b/src/posts/VS@AWvB_Expedition106/index.md
@@ -1,6 +1,6 @@
 ---
 title: 'Live from the Anna Weber-van Bosse vessel!'
-date: '2025-06-29'
+date: '2026-06-29'
 authors:
   - name: Gonçalo Albergaria
     github: GoncaloAlbergaria


### PR DESCRIPTION
Hi Erik,
The blog post shows up twice on the website, first dated 2026 and in the bottom 2025.
Can you check and fix the issue? Thanks!
